### PR TITLE
fix: serialize theme/icon-pack updates to stop overlapping runs

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -25,6 +25,7 @@ import * as ColorUtils from "./utils/colorUtils.js";
 import * as FileUtils from "./utils/fileUtils.js";
 import * as ThemeUtils from "./utils/themeUtils.js";
 import { clearRecolorTimeout } from "./utils/recolorUtils.js";
+import { throwIfCancelled, isCancelledError } from "./utils/cancellation.js";
 
 export default class CustomAccentExtension extends Extension {
   constructor(metadata) {
@@ -36,6 +37,11 @@ export default class CustomAccentExtension extends Extension {
     this._configId = null;
     this._timeoutId = null;
     this._a11ySettings = null;
+    // Serializes every reactive theme/icon-pack update behind a single chain,
+    // and cancels whatever is in flight whenever a newer change arrives, so
+    // rapid color/wallpaper changes never run concurrently (see #20).
+    this._cancellable = null;
+    this._opChain = Promise.resolve();
   }
 
   enable() {
@@ -53,56 +59,81 @@ export default class CustomAccentExtension extends Extension {
       schema_id: "org.gnome.desktop.a11y.interface",
     });
 
-    (async () => {
-      try {
-        await this._autoApplyWallpaperColor();
-      } catch (e) {
-        throw new Error(_("Failed to apply custom style: " + e.message));
-      }
-    })();
+    this._runOperation((cancellable) =>
+      this._autoApplyWallpaperColor(cancellable),
+    );
 
     this._settings.connectObject(
       "changed::accent-color",
-      async () =>
-        this._settings.get_boolean("recolor-folders")
-          ? await this._updateStyles(true, true)
-          : await this._updateStyles(false, true),
+      () =>
+        this._runOperation((cancellable) =>
+          this._settings.get_boolean("recolor-folders")
+            ? this._updateStyles(true, true, cancellable)
+            : this._updateStyles(false, true, cancellable),
+        ),
       "changed::gnome-colors",
-      async () => {
-        if (!this._settings.get_boolean("gnome-colors")) {
-          this._settings.set_boolean("custom-color", false);
-        } else {
-          this._reloadGtkStylesheet()
-        }
-        await this._autoApplyWallpaperColor();
-        await this._updateIconPack();
-      },
+      () =>
+        this._runOperation(async (cancellable) => {
+          if (!this._settings.get_boolean("gnome-colors")) {
+            this._settings.set_boolean("custom-color", false);
+          } else {
+            this._reloadGtkStylesheet();
+          }
+          await this._autoApplyWallpaperColor(cancellable);
+          throwIfCancelled(cancellable);
+          await this._updateIconPack(cancellable);
+        }),
       "changed::tint-shell",
-      async () => await this._updateShellStyles(),
+      () =>
+        this._runOperation((cancellable) =>
+          this._updateShellStyles(cancellable),
+        ),
       "changed::custom-css",
-      async () => await this._updateShellStyles(),
+      () =>
+        this._runOperation((cancellable) =>
+          this._updateShellStyles(cancellable),
+        ),
       "changed::tint-apps",
-      async () => await this._updateAppStyles(),
+      () =>
+        this._runOperation((cancellable) =>
+          this._updateAppStyles(cancellable),
+        ),
       "changed::tint-gtk3",
-      async () => await this._updateAppStyles(),
+      () =>
+        this._runOperation((cancellable) =>
+          this._updateAppStyles(cancellable),
+        ),
       "changed::darker",
-      async () => await this._updateStyles(false, true),
+      () =>
+        this._runOperation((cancellable) =>
+          this._updateStyles(false, true, cancellable),
+        ),
       "changed::recolor-folders",
-      async () => await this._updateIconPack(),
+      () =>
+        this._runOperation((cancellable) =>
+          this._updateIconPack(cancellable),
+        ),
       "changed::recolor-apps",
-      async () => await this._updateIconPack(),
+      () =>
+        this._runOperation((cancellable) =>
+          this._updateIconPack(cancellable),
+        ),
       "changed::morewaita",
-      async () => await this._updateIconPack(),
+      () =>
+        this._runOperation((cancellable) =>
+          this._updateIconPack(cancellable),
+        ),
       this,
     );
 
     this._interfaceSettings.connectObject(
       "changed::color-scheme",
-      async () => {
-        await this._autoApplyWallpaperColor();
-      },
+      () =>
+        this._runOperation((cancellable) =>
+          this._autoApplyWallpaperColor(cancellable),
+        ),
       "changed::accent-color",
-      async () => {
+      () => {
         if (this._settings.get_boolean("gnome-colors")) {
           const newAccent = this._interfaceSettings.get_string("accent-color");
 
@@ -116,15 +147,17 @@ export default class CustomAccentExtension extends Extension {
 
     this._bgSettings.connectObject(
       "changed::picture-uri-dark",
-      async () => {
-        this._settings.set_boolean("custom-color", false);
-        await this._autoApplyWallpaperColor();
-      },
+      () =>
+        this._runOperation((cancellable) => {
+          this._settings.set_boolean("custom-color", false);
+          return this._autoApplyWallpaperColor(cancellable);
+        }),
       "changed::picture-uri",
-      async () => {
-        this._settings.set_boolean("custom-color", false);
-        await this._autoApplyWallpaperColor();
-      },
+      () =>
+        this._runOperation((cancellable) => {
+          this._settings.set_boolean("custom-color", false);
+          return this._autoApplyWallpaperColor(cancellable);
+        }),
       this,
     );
 
@@ -146,6 +179,10 @@ export default class CustomAccentExtension extends Extension {
     // Necessary to keep accent colors consistent when unlocking the session
 
     clearRecolorTimeout();
+
+    this._cancellable?.cancel();
+    this._cancellable = null;
+    this._opChain = Promise.resolve();
 
     this._settings?.disconnectObject(this);
     this._bgSettings?.disconnectObject(this);
@@ -183,6 +220,33 @@ export default class CustomAccentExtension extends Extension {
     this._a11ySettings = null;
   }
 
+  // Cancels any in-flight or already-queued operation, then queues fn to run
+  // once the previous one has unwound. This guarantees at most one theme /
+  // icon-pack update runs at a time, and a burst of rapid changes collapses
+  // to a single run of the latest one instead of overlapping (see #20).
+  _runOperation(fn) {
+    this._cancellable?.cancel();
+
+    const cancellable = new Gio.Cancellable();
+    this._cancellable = cancellable;
+
+    this._opChain = this._opChain.then(async () => {
+      if (cancellable.is_cancelled()) return;
+
+      try {
+        await fn(cancellable);
+      } catch (e) {
+        if (!isCancelledError(e)) {
+          this._settings?.set_string("last-error", e.message);
+        }
+      } finally {
+        if (this._cancellable === cancellable) {
+          this._cancellable = null;
+        }
+      }
+    });
+  }
+
   _updateDesktopFile() {
     const shouldCreate = this._settings.get_boolean("create-shortcut");
     if (shouldCreate) {
@@ -192,9 +256,11 @@ export default class CustomAccentExtension extends Extension {
     }
   }
 
-  async _autoApplyWallpaperColor() {
+  async _autoApplyWallpaperColor(cancellable) {
+    throwIfCancelled(cancellable);
+
     if (this._settings.get_boolean("custom-color")) {
-      await this._updateStyles(false, true);
+      await this._updateStyles(false, true, cancellable);
       return;
     }
 
@@ -206,6 +272,8 @@ export default class CustomAccentExtension extends Extension {
         : this._bgSettings.get_string("picture-uri");
 
     let color = await ColorUtils.calculateVibrantColor(uri);
+    throwIfCancelled(cancellable);
+
     const colorChanged = color !== this._settings.get_string("accent-color");
 
     let updateIcons =
@@ -217,10 +285,12 @@ export default class CustomAccentExtension extends Extension {
       this._settings.set_string("accent-color", color);
     }
 
-    await this._updateStyles(updateIcons, colorChanged);
+    await this._updateStyles(updateIcons, colorChanged, cancellable);
   }
 
-  async _updateIconPack() {
+  async _updateIconPack(cancellable) {
+    throwIfCancelled(cancellable);
+
     const iconFolders = this._settings.get_boolean("recolor-folders");
 
     if (!iconFolders) {
@@ -245,28 +315,37 @@ export default class CustomAccentExtension extends Extension {
         iconApps,
         morewaita,
         gnomeColors,
+        cancellable,
       );
     } catch (error) {
+      if (isCancelledError(error)) throw error;
       this._settings.set_string("last-error", error.message);
     }
   }
 
-  async _updateStyles(updateIcons = false, colorChanged = false) {
+  async _updateStyles(updateIcons = false, colorChanged = false, cancellable) {
+    throwIfCancelled(cancellable);
+
     const gnomeColors = this._settings.get_boolean("gnome-colors");
 
-    await this._updateShellStyles();
-    await this._updateAppStyles();
+    await this._updateShellStyles(cancellable);
+    throwIfCancelled(cancellable);
+    await this._updateAppStyles(cancellable);
 
     if (!gnomeColors && colorChanged) {
+      throwIfCancelled(cancellable);
       this._reloadGtkStylesheet();
     }
 
     if (updateIcons) {
-      await this._updateIconPack();
+      throwIfCancelled(cancellable);
+      await this._updateIconPack(cancellable);
     }
   }
 
-  async _updateShellStyles() {
+  async _updateShellStyles(cancellable) {
+    throwIfCancelled(cancellable);
+
     const color = this._settings.get_string("accent-color");
     const darker = this._settings.get_boolean("darker");
     const colorScheme = this._interfaceSettings.get_string("color-scheme");
@@ -289,10 +368,13 @@ export default class CustomAccentExtension extends Extension {
       darker,
       customCss,
       gnomeColors,
+      cancellable,
     );
   }
 
-  async _updateAppStyles() {
+  async _updateAppStyles(cancellable) {
+    throwIfCancelled(cancellable);
+
     const color = this._settings.get_string("accent-color");
     const gtk3 = this._settings.get_boolean("tint-gtk3");
     const darker = this._settings.get_boolean("darker");
@@ -309,6 +391,7 @@ export default class CustomAccentExtension extends Extension {
       gtk3,
       darker,
       gnomeColors,
+      cancellable,
     );
   }
 

--- a/utils/cancellation.js
+++ b/utils/cancellation.js
@@ -1,0 +1,41 @@
+/*
+ * cancellation.js
+ *
+ * This file is part of ChromaLeon GNOME Shell Extension.
+ * https://github.com/Fabito02/ChromaLeon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import Gio from "gi://Gio";
+import GLib from "gi://GLib";
+
+// GJS is single-threaded, so a running async chain can't be pre-empted; it can
+// only notice cancellation at checkpoints. This throws the same error shape a
+// cancelled Gio async op produces, so both paths unwind identically.
+export function throwIfCancelled(cancellable) {
+  if (cancellable && cancellable.is_cancelled()) {
+    throw new GLib.Error(
+      Gio.IOErrorEnum,
+      Gio.IOErrorEnum.CANCELLED,
+      "Operation superseded by a newer request",
+    );
+  }
+}
+
+export function isCancelledError(e) {
+  return Boolean(e?.matches?.(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED));
+}

--- a/utils/recolorUtils.js
+++ b/utils/recolorUtils.js
@@ -22,6 +22,7 @@
 
 import GLib from "gi://GLib";
 import Gio from "gi://Gio";
+import { throwIfCancelled } from "./cancellation.js";
 
 let timeoutId = null;
 
@@ -84,7 +85,7 @@ function modifyColor(hex, lMod, sMod) {
   return `${toHex(newR)}${toHex(newG)}${toHex(newB)}`;
 }
 
-async function recolorSvgAsync(file, colorMap) {
+async function recolorSvgAsync(file, colorMap, cancellable) {
   return new Promise((resolve) => {
     try {
       if (!file.query_exists(null)) {
@@ -92,7 +93,7 @@ async function recolorSvgAsync(file, colorMap) {
         return;
       }
 
-      file.load_contents_async(null, (obj, res) => {
+      file.load_contents_async(cancellable, (obj, res) => {
         try {
           let [success, contents] = file.load_contents_finish(res);
           if (!success) {
@@ -118,7 +119,7 @@ async function recolorSvgAsync(file, colorMap) {
               null,
               false,
               Gio.FileCreateFlags.REPLACE_DESTINATION,
-              null,
+              cancellable,
               (obj2, res2) => {
                 try {
                   obj2.replace_contents_finish(res2);
@@ -139,14 +140,14 @@ async function recolorSvgAsync(file, colorMap) {
   });
 }
 
-async function processDirectoryAsync(dirPath, colorMap) {
+async function processDirectoryAsync(dirPath, colorMap, cancellable) {
   let dir = Gio.File.new_for_path(dirPath);
   if (!dir.query_exists(null)) return;
 
   let enumerator = dir.enumerate_children(
     "standard::name,standard::type",
     Gio.FileQueryInfoFlags.NONE,
-    null,
+    cancellable,
   );
 
   let filesToProcess = [];
@@ -160,24 +161,32 @@ async function processDirectoryAsync(dirPath, colorMap) {
 
   const chunkSize = 100;
   for (let i = 0; i < filesToProcess.length; i += chunkSize) {
+    throwIfCancelled(cancellable);
+
     const chunk = filesToProcess.slice(i, i + chunkSize);
     await Promise.all(
       chunk.map(async (item) => {
         if (item.type === Gio.FileType.DIRECTORY) {
-          await processDirectoryAsync(item.child.get_path(), colorMap);
+          await processDirectoryAsync(
+            item.child.get_path(),
+            colorMap,
+            cancellable,
+          );
         } else if (
           (item.type === Gio.FileType.REGULAR ||
             item.type === Gio.FileType.SYMBOLIC_LINK) &&
           item.name.endsWith(".svg")
         ) {
-          await recolorSvgAsync(item.child, colorMap);
+          await recolorSvgAsync(item.child, colorMap, cancellable);
         }
       }),
     );
   }
 }
 
-async function deleteRecursiveAsync(file) {
+async function deleteRecursiveAsync(file, cancellable) {
+  throwIfCancelled(cancellable);
+
   if (!file.query_exists(null)) return;
 
   try {
@@ -186,7 +195,7 @@ async function deleteRecursiveAsync(file) {
         "standard::type",
         Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
         GLib.PRIORITY_DEFAULT,
-        null,
+        cancellable,
         (obj, r) => {
           try {
             res(obj.query_info_finish(r));
@@ -203,7 +212,7 @@ async function deleteRecursiveAsync(file) {
           "standard::name",
           Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
           GLib.PRIORITY_DEFAULT,
-          null,
+          cancellable,
           (obj, r) => {
             try {
               res(obj.enumerate_children_finish(r));
@@ -216,21 +225,28 @@ async function deleteRecursiveAsync(file) {
 
       if (iter) {
         while (true) {
+          throwIfCancelled(cancellable);
+
           const infos = await new Promise((res) => {
-            iter.next_files_async(50, GLib.PRIORITY_DEFAULT, null, (obj, r) => {
-              try {
-                res(obj.next_files_finish(r));
-              } catch (e) {
-                res([]);
-              }
-            });
+            iter.next_files_async(
+              50,
+              GLib.PRIORITY_DEFAULT,
+              cancellable,
+              (obj, r) => {
+                try {
+                  res(obj.next_files_finish(r));
+                } catch (e) {
+                  res([]);
+                }
+              },
+            );
           });
 
           if (!infos || infos.length === 0) break;
 
           const branches = infos.map((childInfo) => {
             const child = iter.get_child(childInfo);
-            return deleteRecursiveAsync(child);
+            return deleteRecursiveAsync(child, cancellable);
           });
 
           await Promise.all(branches);
@@ -243,7 +259,7 @@ async function deleteRecursiveAsync(file) {
     }
 
     await new Promise((res) => {
-      file.delete_async(GLib.PRIORITY_DEFAULT, null, (obj, r) => {
+      file.delete_async(GLib.PRIORITY_DEFAULT, cancellable, (obj, r) => {
         try {
           obj.delete_finish(r);
         } catch (e) {}
@@ -253,7 +269,9 @@ async function deleteRecursiveAsync(file) {
   } catch (e) {}
 }
 
-export async function applyAccentTheme(baseColor, options = {}) {
+export async function applyAccentTheme(baseColor, options = {}, cancellable) {
+  throwIfCancelled(cancellable);
+
   const { applyApps = false, useMoreWaita = false } = options;
 
   const darkAccent = modifyColor(baseColor, -0.08, 0.0);
@@ -309,9 +327,13 @@ export async function applyAccentTheme(baseColor, options = {}) {
     throw new Error(_("Adwaita icon pack was not found."));
   }
 
+  throwIfCancelled(cancellable);
+
   if (targetDirFile.query_exists(null)) {
-    await deleteRecursiveAsync(targetDirFile);
+    await deleteRecursiveAsync(targetDirFile, cancellable);
   }
+
+  throwIfCancelled(cancellable);
 
   try {
     if (!targetDirFile.query_exists(null)) {
@@ -337,7 +359,7 @@ export async function applyAccentTheme(baseColor, options = {}) {
           "standard::name,standard::type",
           Gio.FileQueryInfoFlags.NONE,
           GLib.PRIORITY_DEFAULT,
-          null,
+          cancellable,
           (obj, r) => {
             try {
               res(obj.enumerate_children_finish(r));
@@ -351,11 +373,13 @@ export async function applyAccentTheme(baseColor, options = {}) {
       if (!enumerator) return;
 
       while (true) {
+        throwIfCancelled(cancellable);
+
         const infos = await new Promise((res) => {
           enumerator.next_files_async(
             100,
             GLib.PRIORITY_DEFAULT,
-            null,
+            cancellable,
             (obj, r) => {
               try {
                 res(obj.next_files_finish(r));
@@ -384,7 +408,7 @@ export async function applyAccentTheme(baseColor, options = {}) {
                 childDest,
                 Gio.FileCopyFlags.OVERWRITE,
                 GLib.PRIORITY_DEFAULT,
-                null,
+                cancellable,
                 null,
                 (obj, r) => {
                   try {
@@ -407,10 +431,12 @@ export async function applyAccentTheme(baseColor, options = {}) {
     `${sysAdwaita}/scalable/places`,
     `${targetDir}/scalable/places`,
   );
+  throwIfCancelled(cancellable);
   await copyFolderContentAsync(
     `${sysAdwaita}/scalable/status`,
     `${targetDir}/scalable/status`,
   );
+  throwIfCancelled(cancellable);
   await copyFolderContentAsync(
     `${sysAdwaita}/scalable/mimetypes`,
     `${targetDir}/scalable/mimetypes`,
@@ -439,6 +465,8 @@ export async function applyAccentTheme(baseColor, options = {}) {
   ];
 
   if (applyApps) {
+    throwIfCancelled(cancellable);
+
     const appsDestDir = Gio.File.new_for_path(`${targetDir}/scalable/apps`);
 
     if (!appsDestDir.query_exists(null)) {
@@ -448,6 +476,8 @@ export async function applyAccentTheme(baseColor, options = {}) {
     }
 
     for (let app of appsToRecolor) {
+      throwIfCancelled(cancellable);
+
       const userAppFile = Gio.File.new_for_path(`${userHicolorApps}/${app}`);
       const sysAppFile = Gio.File.new_for_path(`${hicolorApps}/${app}`);
       const flatpakSysFile = Gio.File.new_for_path(`${flatpakSysApps}/${app}`);
@@ -474,7 +504,7 @@ export async function applyAccentTheme(baseColor, options = {}) {
             destFile,
             Gio.FileCopyFlags.OVERWRITE,
             GLib.PRIORITY_DEFAULT,
-            null,
+            cancellable,
             null,
             (obj, r) => {
               try {
@@ -489,6 +519,8 @@ export async function applyAccentTheme(baseColor, options = {}) {
   }
 
   if (useMoreWaita) {
+    throwIfCancelled(cancellable);
+
     const possiblePaths = [
       "/usr/share/icons/MoreWaita",
       `${homeDir}/.local/share/icons/MoreWaita`,
@@ -514,6 +546,8 @@ export async function applyAccentTheme(baseColor, options = {}) {
       throw new Error(_("MoreWaita icon pack was not found."));
     }
   }
+
+  throwIfCancelled(cancellable);
 
   const rebelApps = {
     "org.gnome.Calendar.svg": {
@@ -569,12 +603,26 @@ export async function applyAccentTheme(baseColor, options = {}) {
     },
   };
 
-  await processDirectoryAsync(`${targetDir}/scalable/places`, colorMap);
-  await processDirectoryAsync(`${targetDir}/scalable/mimetypes`, colorMap);
-  await processDirectoryAsync(`${targetDir}/scalable/status`, colorMap);
+  await processDirectoryAsync(
+    `${targetDir}/scalable/places`,
+    colorMap,
+    cancellable,
+  );
+  await processDirectoryAsync(
+    `${targetDir}/scalable/mimetypes`,
+    colorMap,
+    cancellable,
+  );
+  await processDirectoryAsync(
+    `${targetDir}/scalable/status`,
+    colorMap,
+    cancellable,
+  );
 
   if (applyApps) {
     for (let appName of appsToRecolor) {
+      throwIfCancelled(cancellable);
+
       let appFile = Gio.File.new_for_path(
         `${targetDir}/scalable/apps/${appName}`,
       );
@@ -582,10 +630,13 @@ export async function applyAccentTheme(baseColor, options = {}) {
         await recolorSvgAsync(
           appFile,
           rebelApps[appName] ? rebelApps[appName] : colorMap,
+          cancellable,
         );
       }
     }
   }
+
+  throwIfCancelled(cancellable);
 
   let directories = [
     "scalable/places",
@@ -636,7 +687,7 @@ Type=Scalable
       null,
       false,
       Gio.FileCreateFlags.REPLACE_DESTINATION,
-      null,
+      cancellable,
       (obj, res) => {
         try {
           obj.replace_contents_finish(res);
@@ -645,6 +696,8 @@ Type=Scalable
       },
     );
   });
+
+  throwIfCancelled(cancellable);
 
   await new Promise((resolve) => {
     const settings = Gio.Settings.new("org.gnome.desktop.interface");

--- a/utils/themeUtils.js
+++ b/utils/themeUtils.js
@@ -24,6 +24,7 @@ import St from "gi://St";
 import Gio from "gi://Gio";
 import GLib from "gi://GLib";
 import { applyAccentTheme } from "./recolorUtils.js";
+import { throwIfCancelled } from "./cancellation.js";
 
 const GTK_VERSIONS = ["gtk-3.0", "gtk-4.0"];
 const REGEX_MARKER =
@@ -106,7 +107,10 @@ export async function updateShellStylesheet(
   darker,
   customStyle,
   gnomeColors,
+  cancellable,
 ) {
+  throwIfCancelled(cancellable);
+
   if (gnomeColors) color = "-st-accent-color";
 
   const homeDir = GLib.get_home_dir();
@@ -140,7 +144,7 @@ export async function updateShellStylesheet(
 
   const generateAndApplyFiles = async (customCssContents) => {
     try {
-      let [contents] = await finalTemplate.load_contents_async(null);
+      let [contents] = await finalTemplate.load_contents_async(cancellable);
 
       let template = new TextDecoder().decode(contents);
       let finalTemplateContent = customCssContents
@@ -161,8 +165,10 @@ export async function updateShellStylesheet(
         null,
         false,
         Gio.FileCreateFlags.REPLACE_DESTINATION,
-        null,
+        cancellable,
       );
+
+      throwIfCancelled(cancellable);
 
       removeShellStylesheet(currentCssFile);
 
@@ -178,7 +184,7 @@ export async function updateShellStylesheet(
     if (customStyle) {
       let customCssContents = null;
       try {
-        let [contents] = await customCss.load_contents_async(null);
+        let [contents] = await customCss.load_contents_async(cancellable);
         customCssContents = new TextDecoder().decode(contents);
       } catch (e) {}
       await generateAndApplyFiles(customCssContents);
@@ -198,7 +204,7 @@ export async function updateShellStylesheet(
         null,
         false,
         Gio.FileCreateFlags.REPLACE_DESTINATION,
-        null,
+        cancellable,
       );
     } catch (e) {}
     await generateAndApplyFiles(null);
@@ -213,7 +219,10 @@ export async function updateGtkStylesheet(
   tintGTK3,
   darker,
   gnomeColors,
+  cancellable,
 ) {
+  throwIfCancelled(cancellable);
+
   const configDir = GLib.get_user_config_dir();
   const cssBlock = `${START_MARKER}\n@import url("custom-accent.css");\n${END_MARKER}`;
   const cssVars = `@define-color accent_color ${color};\n@define-color accent_bg_color ${color};\n`;
@@ -241,7 +250,7 @@ export async function updateGtkStylesheet(
       null,
       false,
       Gio.FileCreateFlags.REPLACE_DESTINATION,
-      null,
+      cancellable,
     );
   };
 
@@ -261,7 +270,7 @@ export async function updateGtkStylesheet(
           null,
           false,
           Gio.FileCreateFlags.NONE,
-          null,
+          cancellable,
         );
       } catch (e) {}
     }
@@ -270,7 +279,8 @@ export async function updateGtkStylesheet(
       let tintedGtk4Template = tintedGtk4Style;
       if (darker) tintedGtk4Template = tintedGtk4DarkerStyle;
       try {
-        let [contents] = await tintedGtk4Template.load_contents_async(null);
+        let [contents] =
+          await tintedGtk4Template.load_contents_async(cancellable);
 
         let template = new TextDecoder().decode(contents);
         let css = template.replace(
@@ -292,13 +302,13 @@ export async function updateGtkStylesheet(
         null,
         false,
         Gio.FileCreateFlags.REPLACE_DESTINATION,
-        null,
+        cancellable,
       );
     };
 
     if (mainFile.query_exists(null)) {
       try {
-        let [contents] = await mainFile.load_contents_async(null);
+        let [contents] = await mainFile.load_contents_async(cancellable);
         let mainContent = new TextDecoder().decode(contents);
         let cleanContent = mainContent.replace(REGEX_MARKER, "").trim();
 
@@ -325,7 +335,7 @@ export async function updateGtkStylesheet(
           null,
           false,
           Gio.FileCreateFlags.NONE,
-          null,
+          cancellable,
         );
       } catch (e) {}
     }
@@ -335,7 +345,8 @@ export async function updateGtkStylesheet(
         let tintedGtk3Template = tintedGtk3DarkStyle;
         if (darker) tintedGtk3Template = tintedGtk3DarkerStyle;
         try {
-          let [contents] = await tintedGtk3Template.load_contents_async(null);
+          let [contents] =
+            await tintedGtk3Template.load_contents_async(cancellable);
 
           let template = new TextDecoder().decode(contents);
           let css = template.replace(
@@ -349,7 +360,8 @@ export async function updateGtkStylesheet(
         } catch (e) {}
       } else {
         try {
-          let [contents] = await tintedGtk3LightStyle.load_contents_async(null);
+          let [contents] =
+            await tintedGtk3LightStyle.load_contents_async(cancellable);
 
           let template = new TextDecoder().decode(contents);
           let css = template.replace(
@@ -373,13 +385,13 @@ export async function updateGtkStylesheet(
         null,
         false,
         Gio.FileCreateFlags.REPLACE_DESTINATION,
-        null,
+        cancellable,
       );
     };
 
     if (mainFile.query_exists(null)) {
       try {
-        let [contents] = await mainFile.load_contents_async(null);
+        let [contents] = await mainFile.load_contents_async(cancellable);
         let mainContent = new TextDecoder().decode(contents);
         let cleanContent = mainContent.replace(REGEX_MARKER, "").trim();
 
@@ -391,6 +403,7 @@ export async function updateGtkStylesheet(
   };
 
   await gtk4();
+  throwIfCancelled(cancellable);
   await gtk3();
 }
 
@@ -400,7 +413,10 @@ export async function updateIconPack(
   iconApps,
   morewaita,
   gnomeColors,
+  cancellable,
 ) {
+  throwIfCancelled(cancellable);
+
   let color = hex;
 
   if (gnomeColors) {
@@ -422,8 +438,12 @@ export async function updateIconPack(
     return;
   }
 
-  await applyAccentTheme(color, {
-    applyApps: iconApps,
-    useMoreWaita: morewaita,
-  });
+  await applyAccentTheme(
+    color,
+    {
+      applyApps: iconApps,
+      useMoreWaita: morewaita,
+    },
+    cancellable,
+  );
 }


### PR DESCRIPTION
## Summary

Fixes #20. Rapid accent-color/wallpaper changes could fire multiple concurrent theme and icon-pack updates, since every reactive GSettings handler in `extension.js` was an independent, un-awaited `async` callback with no coordination between them.

- Add a `Gio.Cancellable`-based operation runner (`_runOperation`) in `extension.js`: every reactive handler now cancels whatever is currently in flight and queues its own work behind it, so a burst of rapid changes collapses to a single run of the latest one instead of overlapping.
- Thread the cancellable through `utils/themeUtils.js` and `utils/recolorUtils.js`, with cooperative checkpoints (`throwIfCancelled`) at each batch/phase boundary in the delete/copy/recolor path (`applyAccentTheme`) and the GTK stylesheet read-modify-write path, plus native `Gio.Cancellable` slots on the underlying async file operations so a superseded run aborts quickly instead of racing to completion.

### Reproduction

Verified with a standalone harness that drives the real `applyAccentTheme()` under two dispatch modes: the old fire-and-forget pattern vs. the new cancel-and-queue pattern.

**Before the fix:** peak concurrency of 4 simultaneous `applyAccentTheme()` runs from a burst of 5 rapid triggers. Two concrete failure modes observed:
- The final `Adwaita-Dynamic` icon tree ended up with two different accent colors mixed across its own files (visible corruption).
- 2 of 5 calls **hung forever** (never resolved or rejected). Root cause: the final icon-theme-reload step uses a module-level `timeoutId` shared across all concurrent calls; a later call's `GLib.source_remove(timeoutId)` can destroy an earlier call's still-pending 200ms timer, and that earlier call's `resolve()` lived inside the destroyed callback — so its promise never settles. This is a second, more severe mechanism behind the "system freezes" symptom in the original report, on top of the file-corruption path.

**After the fix:** peak concurrency is always 1. Superseded runs cancel cleanly in ~30ms instead of racing to completion. Only the final trigger's color survives on disk. Zero hangs across repeated runs.

## Test plan

- [x] Static syntax check (`node --check`) on all changed files
- [x] Standalone reproduction harness confirming both failure modes before the fix and their absence after
- [x] Manual install + live GNOME Shell testing: rapid wallpaper/dark-mode toggling, verified no icon corruption, CPU settles quickly, `disable()` cleans up correctly (GTK stylesheets, marker blocks, desktop shortcut all removed)

## Note

A second, related bug (icon-copy truncation from a `forEach`/`Promise.all` mismatch in `recolorUtils.js`) was found during this investigation but is intentionally left out of this PR — will follow up separately, as discussed in #25.